### PR TITLE
Changes for dark theme

### DIFF
--- a/data/2023/style/custom.css
+++ b/data/2023/style/custom.css
@@ -2,11 +2,13 @@
     border: 3.0px solid #333;
     padding: 12px 18px;
     background-color: #C8D3FD;
+    color: #333
 }
 
 h2 {
     padding: 12px 18px;
     background-color: #C8D3FD;
+    color: #333
 }
 
 .question {

--- a/data/2025/style/custom.css
+++ b/data/2025/style/custom.css
@@ -3,11 +3,13 @@ h1 {
     border: 3.0px solid #333;
     padding: 12px 18px;
     background-color: #C8D3FD;
+    color: #333
 }
 
 h2 {
     padding: 12px 18px;
     background-color: #C8D3FD;
+    color: #333
 }
 
 .question {


### PR DESCRIPTION
When a dark theme is used, the default font color changes to white, this is hard to read on some of the panels with an explicit background color.
 
Added color css so that a themes default is not just used when a background colour is explicitly set